### PR TITLE
Fix the issue where "HEADLINE_LINE_OUTPUT" is not used as part of the prompt in prompt mode

### DIFF
--- a/headline.zsh-theme
+++ b/headline.zsh-theme
@@ -458,9 +458,9 @@ headline_precmd() {
   fi
 
   # Separator line
-  _HEADLINE_LINE_OUTPUT="$_HEADLINE_LINE_LEFT$_HEADLINE_LINE_RIGHT$reset"
+  _HEADLINE_LINE_OUTPUT=""
   if [[ $HEADLINE_LINE_MODE == 'on' || ($HEADLINE_LINE_MODE == 'auto' && $_HEADLINE_DO_SEP == 'true' ) ]]; then
-    print -rP $_HEADLINE_LINE_OUTPUT
+    _HEADLINE_LINE_OUTPUT="$_HEADLINE_LINE_LEFT$_HEADLINE_LINE_RIGHT$reset"
   fi
   _HEADLINE_DO_SEP='true'
 
@@ -469,10 +469,11 @@ headline_precmd() {
 
   # Prompt
   if [[ $HEADLINE_INFO_MODE == 'precmd' ]]; then
+    [ ! -z ${_HEADLINE_LINE_OUTPUT} ] && print -rP $_HEADLINE_LINE_OUTPUT
     print -rP $_HEADLINE_INFO_OUTPUT
     PROMPT=$HEADLINE_PROMPT
   else
-    PROMPT='$(print -rP $_HEADLINE_INFO_OUTPUT; print -rP $HEADLINE_PROMPT)'
+    PROMPT='$([ ! -z ${_HEADLINE_LINE_OUTPUT} ] && print -rP $_HEADLINE_LINE_OUTPUT; print -rP $_HEADLINE_INFO_OUTPUT; print -rP $HEADLINE_PROMPT)'
   fi
 
   # Right prompt


### PR DESCRIPTION
In prompt mode, when I press `Ctrl+L` (with `HEADLINE_LINE_MODE=on`), I expect to get
![Снимок экрана от 2024-09-22 03-57-47](https://github.com/user-attachments/assets/6e563962-3ba6-4a23-9129-c03432fc3bb0)
but instead, I get
![Снимок экрана от 2024-09-22 03-56-18](https://github.com/user-attachments/assets/0f83329e-0c9c-4f98-8653-2387862e2cb0)
These changes fix the behavior of the `PROMPT` variable and propagate `HEADLINE_LINE_OUTPUT` if `HEADLINE_LINE_MODE` is on