### PR TITLE
Fix the missing PROMPT assignment if HL_PRINT_MODE is off

### DIFF
--- a/headline.zsh-theme
+++ b/headline.zsh-theme
@@ -473,7 +473,9 @@ headline-clear-screen() {
   print -nr "$cursor_hide$cursor_to_top_left_corner$clear_entire_screen"
 
   # Update and print
-  headline-precmd
+  for function in $precmd_functions; do
+    $function
+  done
   zle .reset-prompt # re-print $PROMPT and $RPROMPT
 
   # Show cursor

--- a/headline.zsh-theme
+++ b/headline.zsh-theme
@@ -557,7 +557,7 @@ headline-precmd() {
     (( target_length -= $remove ))
     contents[$key]=''; (( content_length -= $content_lengths[$key] )); content_lengths[$key]=0
     layouts[$key]=''; (( layout_length -= $layout_lengths[$key] )); layout_lengths[$key]=0
-  
+
     # Update first segment
     for key in $HL_LAYOUT_ORDER; do
       [[ $key == '_PRE' ]] && continue # skip special segment
@@ -666,13 +666,13 @@ headline-precmd() {
   _HL_INFO=$information
 
   # Prompt
-  if [[ $HL_PRINT_MODE == 'precmd' ]]; then
-    PROMPT=$HL_PROMPT
-  elif [[ $HL_PRINT_MODE == 'prompt' ]]; then
+  if [[ $HL_PRINT_MODE == 'prompt' ]]; then
     PROMPT='$('
     (( ${#HL_OUTPUT_SEP} )) && PROMPT+='print -rP "$HL_OUTPUT_SEP"; '
     (( ${#HL_OUTPUT_INFO} )) && PROMPT+='print -rP "$HL_OUTPUT_INFO"; '
     PROMPT+='print -rP "$HL_PROMPT")'
+  else
+    PROMPT=$HL_PROMPT
   fi
 
   # Right prompt

--- a/headline.zsh-theme
+++ b/headline.zsh-theme
@@ -467,6 +467,7 @@ zle -N headline-clear-screen
 bindkey '^L' headline-clear-screen
 headline-clear-screen() {
   _HL_AT_TOP='true'
+  _HL_INFO='' # ensure info line will print
 
   # Hide cursor and clear screen
   print -nr "$cursor_hide$cursor_to_top_left_corner$clear_entire_screen"


### PR DESCRIPTION
When I set `HL_PRINT_MODE` to `off`, I expected to get:
![Снимок экрана от 2024-10-13 08-11-16](https://github.com/user-attachments/assets/0fd58aa4-9bf1-4465-933a-5c19b3b721e6)
but instead, I get:
![Снимок экрана от 2024-10-13 08-11-46](https://github.com/user-attachments/assets/6f139f07-0d72-4180-b3b6-3499f0344b6c)
These changes apply the default prompt settings in any mode